### PR TITLE
chore(simple-icons): add support for simple-icons v15

### DIFF
--- a/libs/nx-generators/src/generators/simple-icons/generator.ts
+++ b/libs/nx-generators/src/generators/simple-icons/generator.ts
@@ -89,11 +89,21 @@ function generateIconsComponents(
 
     //Colors
     const title = getSvgTitle(svgFileContent);
+    const simpleIconsPackageJsonPath = path.join(
+      workspaceRoot,
+      'node_modules',
+      'simple-icons',
+      'package.json',
+    );
+    const packageJson = JSON.parse(
+      fs.readFileSync(simpleIconsPackageJsonPath, 'utf-8'),
+    ) as { version: string };
+    const [major] = packageJson.version.split('.');
     const simpleIconsJsonPath = path.join(
       workspaceRoot,
       'node_modules',
       'simple-icons',
-      '_data',
+      Number(major) >= 15 ? 'data' : '_data',
       'simple-icons.json',
     );
     const simpleIconsJson: SimpleIcon[] = readJsonFile(simpleIconsJsonPath);


### PR DESCRIPTION
See https://github.com/simple-icons/simple-icons/pull/13316. We're going to rename the `_data` folder to `data`.

I've expanded the condition for the next major version.